### PR TITLE
Disabling SDK-Reference Docs _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ exclude:
   - .idea/
   - .gitignore
   - vendor
-#  - pages/sdk-reference
+  - pages/sdk-reference
 # these are the files and directories that jekyll will exclude from the build
 
 feedback_subject_line: Samsung Health Stack Feedback


### PR DESCRIPTION
Currently, the GitHub Pages is overloaded with content, testing if taking out SDK Reference solves it.